### PR TITLE
Add JST datetime display to index.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 CLAUDE.local.md
 .DS_Store
 .worktrees
+node_modules
+test-results

--- a/apps/index.html
+++ b/apps/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <p>It works</p>
-  <p id="datetime"></p>
+  <p id="datetime" aria-live="polite" aria-label="現在日時"></p>
   <script>
     function updateDateTime() {
       const now = new Date();

--- a/apps/index.html
+++ b/apps/index.html
@@ -7,5 +7,15 @@
 </head>
 <body>
   <p>It works</p>
+  <p id="datetime"></p>
+  <script>
+    function updateDateTime() {
+      const now = new Date();
+      const jst = now.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
+      document.getElementById('datetime').textContent = jst;
+    }
+    updateDateTime();
+    setInterval(updateDateTime, 1000);
+  </script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "add-jst-datetime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "add-jst-datetime",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@playwright/test": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "add-jst-datetime",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@playwright/test": "^1.58.2"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    browserName: 'chromium',
+  },
+});

--- a/tests/jst-datetime.spec.ts
+++ b/tests/jst-datetime.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const htmlPath = `file://${path.resolve(__dirname, '../apps/index.html')}`;
+
+test('displays JST datetime in #datetime element', async ({ page }) => {
+  await page.goto(htmlPath);
+
+  const datetime = page.locator('#datetime');
+  await expect(datetime).toBeVisible();
+
+  const text = await datetime.textContent();
+  // ja-JP locale with Asia/Tokyo timezone produces format like "2026/2/9 15:30:00"
+  expect(text).toMatch(/^\d{4}\/\d{1,2}\/\d{1,2} \d{1,2}:\d{2}:\d{2}$/);
+});
+
+test('datetime updates after 1 second', async ({ page }) => {
+  await page.goto(htmlPath);
+
+  const datetime = page.locator('#datetime');
+  const firstText = await datetime.textContent();
+
+  await page.waitForTimeout(1500);
+
+  const secondText = await datetime.textContent();
+  expect(secondText).not.toBe(firstText);
+});


### PR DESCRIPTION
## Summary
- Add a `#datetime` element and JavaScript to display current date/time in JST (Asia/Tokyo), updating every second
- Add Playwright test suite verifying datetime format and auto-update behavior
- Update `.gitignore` to exclude `node_modules` and `test-results`

## Test plan
- [x] Open `apps/index.html` in a browser and confirm JST datetime is displayed
- [x] Wait a few seconds and verify the time updates every second
- [x] Run `npx playwright test` and confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)